### PR TITLE
Some lintian issues

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,6 +31,7 @@ Description: C++ bindings to libpmemobj
  This package contains the development headers.
 
 Package: libpmemobj-cpp-doc
+Section: doc
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends}

--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Section: doc
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Description: C++ bindings to libpmemobj
+Description: C++ bindings to libpmemobj - documentation
  The C++ bindings provide an easier to use (and thus less error prone
  version) of libpmemobj -- the persistent memory object store -- through
  the implementation of a pmem-resident property, persistent pointers,

--- a/debian/libpmemobj-cpp-doc.doc-base
+++ b/debian/libpmemobj-cpp-doc.doc-base
@@ -1,0 +1,9 @@
+Document: libpmemobj
+Title: PMDK libpmemobj C++ bindings Manual
+Author: PMDK Developers
+Abstract: This is the HTML docs for the C++ bindings for PMDK's libpmemobj.
+Section: Programming
+
+Format: HTML
+Index: /usr/share/doc/libpmemobj-cpp/index.html
+Files: /usr/share/doc/libpmemobj-cpp/*


### PR DESCRIPTION
Some minor lintian issues:
```
I: libpmemobj-cpp source: duplicate-short-description libpmemobj-cpp-dev libpmemobj-cpp-doc
I: libpmemobj-cpp source: quilt-patch-missing-description no_libdir
I: libpmemobj-cpp-doc: wrong-section-according-to-package-name libpmemobj-cpp-doc => doc
I: libpmemobj-cpp-doc: possible-documentation-but-no-doc-base-registration
```
The only remaining one after this is the missing dep3 header on the no_libdir patch.