### PR TITLE
d/control: change libpmemobj-cpp-dev to be amd64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Vcs-Git: https://github.com/kilobyte/libpmemobj-cpp.git -b debian
 
 Package: libpmemobj-cpp-dev
 Section: libdevel
-Architecture: any
+Architecture: amd64
 Multi-Arch: same
 Depends: libpmemobj-dev, ${misc:Depends}, ${shlibs:Depends}
 Description: C++ bindings to libpmemobj


### PR DESCRIPTION
libpmemobj-cpp-dev has a depends on libpmemobj-dev which is amd64 only.
Furthermore, libpmemobj-cpp [src] has a build-depends on that package as well.
