### PR TITLE
d/control: version libpmemobj-cpp-dev's depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Package: libpmemobj-cpp-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: libpmemobj-dev, ${misc:Depends}, ${shlibs:Depends}
+Depends: libpmemobj-dev (>= 1.5~), ${misc:Depends}, ${shlibs:Depends}
 Description: C++ bindings to libpmemobj
  The C++ bindings provide an easier to use (and thus less error prone
  version) of libpmemobj -- the persistent memory object store -- through


### PR DESCRIPTION
Match libpmemobj-cpp-dev's depends version with the source package's
build-depends.

Upstream's README [states](https://github.com/pmem/libpmemobj-cpp/blob/master/README.md) that libpmemobj-cpp needs at least libpmemobj >= 1.4, but here we are requiring >= 1.5~. I suspect that maybe this is when this package was first created, at version 1.5, in which case we should also bump this version to 1.6 now? In any case, I think both build-depends and depends should match.