### PR TITLE
  * d/t/control: add missing libdaxctl-dev and libndctl-dev dep8 depe…

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,8 +1,8 @@
 Tests: array-pc
-Depends: g++, make, cmake, libpmemobj-cpp-dev, pkg-config
+Depends: g++, make, cmake, libpmemobj-cpp-dev, libndctl-dev, libdaxctl-dev, pkg-config
 
 Tests: array-clang
-Depends: clang, make, cmake, libpmemobj-cpp-dev, pkg-config
+Depends: clang, make, cmake, libpmemobj-cpp-dev, libndctl-dev, libdaxctl-dev, pkg-config
 
 Tests: pmpong
 Depends: g++, make, cmake, libpmemobj-cpp-dev, libsfml-dev, fontconfig


### PR DESCRIPTION
Hi,

it looks like when the libpmemobj-cpp DEP8 tests are run with pmdk 1.6.1~rc1 in Ubuntu, two new dependencies must be explicitly declared: `libndctl-dev` and `libdaxctl-dev`. Otherwise:
```
...
autopkgtest [21:45:46]: test array-pc: [-----------------------
-- The CXX compiler identification is GNU 9.2.1
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Checking for module 'libpmemobj++'
CMake Error at /usr/share/cmake-3.13/Modules/FindPkgConfig.cmake:452 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.13/Modules/FindPkgConfig.cmake:622 (_pkg_check_modules_internal)
  CMakeLists.txt:42 (pkg_check_modules)


--   Package 'libndctl', required by 'libpmemobj', not found
-- Configuring incomplete, errors occurred!
```
After installing `libndctl-dev`, it complained about missing `libdaxctl`, which was resolved by installing `libdaxctl-dev`.

That being said, I couldn't reproduce this error in debian/sid with experimental enabled. I have no idea why it works in debian without libndctl-dev and without libdaxctl-dev.

If this is not expected, then there is something wrong with pmdk 1.6.1~rc1 in the Ubuntu build perhaps.